### PR TITLE
Fix failing VM creation

### DIFF
--- a/vmcloak/platforms/qemu.py
+++ b/vmcloak/platforms/qemu.py
@@ -59,7 +59,6 @@ def _make_pre_v41_args(attr):
         "-device", "usb-ehci,id=ehci",
         "-device", "usb-tablet,bus=ehci.0",
         "-device", "intel-hda",
-        "-device", "hda-duplex",
         "--enable-kvm"
     ]
 
@@ -84,7 +83,6 @@ def _make_post_v41_args(attr):
         "-device", "usb-ehci,id=ehci",
         "-device", "usb-tablet,bus=ehci.0",
         "-device", "intel-hda",
-        "-device", "hda-duplex",
         "-enable-kvm"
     ]
 


### PR DESCRIPTION
Old warning of missing audio driver has now become breaking error. It fails silently in VMCloak with ValueError.
Removed '-device hda-duplex' to remove the failing error.

Tested:
- Locally in VM
- Currently still failing at other parts where assets have been removed from cuckoo.sh

Fixes cert-ee/cuckoo3#183