### PR TITLE
Remove missing assets from install.py

### DIFF
--- a/vmcloak/install.py
+++ b/vmcloak/install.py
@@ -17,9 +17,9 @@ class InstallError(Exception):
     pass
 
 _recipes = {
-    "win10x64": ["ie11", "dotnet:4.7.2", "java:7u80", "vcredist:2013",
+    "win10x64": ["ie11", "dotnet:4.7.2", "vcredist:2013",
                  "vcredist:2019", "edge", "carootcert", "adobepdf",
-                 "wallpaper", "optimizeos", "disableservices"],
+                 "optimizeos", "disableservices"],
     "win7x64": ["ie11", "dotnet:4.7.2", "java:7u80", "vcredist:2013",
                  "vcredist:2019", "carootcert", "adobepdf", "wallpaper",
                 "optimizeos", "disableservices"]


### PR DESCRIPTION
Temporarily removed missing assets `java:7u80` and `wallpaper` from install.py file to fix asstes missing from offline `cuckoo.sh` site

Fixes cert-ee/cuckoo3#213
Fixes cert-ee/cuckoo3#208