### PR TITLE
Revert write input type

### DIFF
--- a/vmcloak/platforms/qemu.py
+++ b/vmcloak/platforms/qemu.py
@@ -282,12 +282,12 @@ def create_snapshot(name):
     confdumps[name].add_machine_field("memory_snapshot", MEMORY_SNAPSHOT_NAME)
     # Stop the machine so the memory does not change while making the
     # memory snapshot.
-    m.stdin.write("stop\n")
-    m.stdin.write("migrate_set_speed 1G\n")
+    m.stdin.write(b"stop\n")
+    m.stdin.write(b"migrate_set_speed 1G\n")
     # Send the actual memory snapshot command. The args helper tries to find
     # lz4 of gzip binaries so we can compress the dump.
-    m.stdin.write(f'migrate "exec:{_get_exec_args(snapshot_path)}"\n')
-    m.stdin.write("quit\n")
+    m.stdin.write(f'migrate "exec:{_get_exec_args(snapshot_path)}"\n'.encode())
+    m.stdin.write(b"quit\n")
     log.debug("Flushing snapshot commands to qemu.")
     m.stdin.flush()
     m.wait()
@@ -393,7 +393,7 @@ class VM(Machinery):
                 "Cannot attach ISO to machine. Process handle not available."
             )
 
-        m.stdin.write(f"change cdrom {iso_path}\n")
+        m.stdin.write(f"change cdrom {iso_path}\n".encode())
         m.stdin.flush()
 
     def detach_iso(self):
@@ -402,5 +402,5 @@ class VM(Machinery):
             raise KeyError(
                 "Cannot attach ISO to machine. Process handle not available."
             )
-        m.stdin.write("eject cdrom\n")
+        m.stdin.write(b"eject cdrom\n")
         m.stdin.flush()


### PR DESCRIPTION
str write() function stopped working. Must be related to versioning and need to look into it when migrating to 3.13.

For now switching back to type binary for stdin.write() functions.